### PR TITLE
Filter away /32 and some odd broken route

### DIFF
--- a/fib_optimizer/fib_optimizer.py
+++ b/fib_optimizer/fib_optimizer.py
@@ -133,6 +133,9 @@ def build_prefix_lists():
     def _build_pl(name, prefixes):
         pl = ''
         for s, p in prefixes.iteritems():
+            prefix, mask = p.split('/')
+            if mask == '32' or (prefix == '' and mask == '0'):
+                continue
             pl += 'seq {} permit {}\n'.format(s, p)
 
         with open('{}/{}'.format(conf['path'], name), "w") as f:


### PR DESCRIPTION
Hi the /32 we have already talked about. The other filter is for a route looking like '/0' ending up in the prefix lists, still not sure where that comes from but this fixes the issue until the root cause is found.
